### PR TITLE
Run flake8 on CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,6 +27,7 @@ devToolsProject.run(
         }
       },
       black: { data.venv.run('black --check .') },
+      flake8: { data.venv.run('flake8 -v') },
       groovylint: { groovylint.checkSingleFile(path: './Jenkinsfile') },
       molecule: { data.venv.run('molecule --debug test') },
     )

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -1,8 +1,8 @@
 """Molecule tests for the default scenario."""
 
 import os
-import pytest
 
+import pytest
 import testinfra.utils.ansible_runner
 
 

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -1,3 +1,5 @@
+"""Molecule tests for the default scenario."""
+
 import os
 import pytest
 
@@ -11,6 +13,7 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 @pytest.mark.parametrize("version", ["5.0", "6.0", "7", "11", "12"])
 def test_clang_versions_installed(host, version):
+    """Test that expected clang versions were installed."""
     clang_link_file = host.file(f"/usr/bin/clang-{version}")
     assert clang_link_file.is_symlink
     clang_bin_file = host.file(clang_link_file.linked_to)

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -1,6 +1,9 @@
 ansible
 ansible-lint
 black
+flake8
+flake8-docstrings
+flake8-isort
 molecule
 molecule-docker
 pytest-testinfra

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -65,10 +65,21 @@ enrich==1.2.6
     # via
     #   ansible-lint
     #   molecule
+flake8==3.9.2
+    # via
+    #   -r requirements-dev.in
+    #   flake8-docstrings
+    #   flake8-isort
+flake8-docstrings==1.6.0
+    # via -r requirements-dev.in
+flake8-isort==4.0.0
+    # via -r requirements-dev.in
 idna==2.10
     # via requests
 iniconfig==1.0.0
     # via pytest
+isort==5.9.3
+    # via flake8-isort
 jinja2==2.11.3
     # via
     #   ansible-core
@@ -79,6 +90,8 @@ jinja2-time==0.2.0
     # via cookiecutter
 markupsafe==1.1.1
     # via jinja2
+mccabe==0.6.1
+    # via flake8
 molecule==3.4.0
     # via
     #   -r requirements-dev.in
@@ -107,8 +120,14 @@ poyo==0.5.0
     # via cookiecutter
 py==1.10.0
     # via pytest
+pycodestyle==2.7.0
+    # via flake8
 pycparser==2.20
     # via cffi
+pydocstyle==6.1.1
+    # via flake8-docstrings
+pyflakes==2.3.1
+    # via flake8
 pygments==2.8.0
     # via rich
 pynacl==1.4.0
@@ -160,10 +179,14 @@ six==1.15.0
     #   python-dateutil
     #   tenacity
     #   websocket-client
+snowballstemmer==2.1.0
+    # via pydocstyle
 subprocess-tee==0.3.2
     # via molecule
 tenacity==7.0.0
     # via ansible-lint
+testfixtures==6.18.1
+    # via flake8-isort
 text-unidecode==1.3
     # via python-slugify
 toml==0.10.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,11 @@
+[flake8]
+exclude = .git,.venv
+filename = *.py
+ignore = W503
+max-line-length = 90
+
+[isort]
+profile = black
+lines_after_imports = 2
+lines_between_types = 1
+order_by_type = False


### PR DESCRIPTION
- Add flake8 to Python requirements
- Add docstrings to tests
- Arrange imports correctly
- Run flake8 on CI
